### PR TITLE
Add a second chime_slow_pulsar_writer object to configs

### DIFF
--- a/json_files/rfi_16k/21-03-07-low-latency-uniform-badchannel-mask-noplot.json
+++ b/json_files/rfi_16k/21-03-07-low-latency-uniform-badchannel-mask-noplot.json
@@ -1147,7 +1147,13 @@
         },
         {
             "class_name": "chime_slow_pulsar_writer",
-            "nt_chunk": 1024
+            "nt_chunk": 1024,
+            "name": "champss"
+        },
+        {
+            "class_name": "chime_slow_pulsar_writer",
+            "nt_chunk": 1024,
+            "name": "slow"
         },
         {
             "class_name": "polynomial_detrender", 


### PR DESCRIPTION
Relevant pull reqeusts:
https://github.com/kmsmith137/rf_pipelines/pull/31
https://github.com/kmsmith137/ch_frb_l1/pull/45

Currently being tested and run on `cfdn1` under "sps-slow-test".

@dstndstn 